### PR TITLE
Fix broken hamburger menu on mobile

### DIFF
--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -63,7 +63,7 @@
 
         <script src="{{ mix('js/main.js', 'assets/build') }}"></script>
 
-        @yield('scripts')
+        @stack('scripts')
 
         <footer class="bg-white text-center text-xs mt-12 py-4" role="contentinfo">
             <p>


### PR DESCRIPTION
## Overview

This pull request changes how the JavaScript files are being rendered in the master layout. 
`@yield('scripts')` changed to `@stack('scripts')`

### Trello
1. [Hamburger button on the blog starter template doesn't work](https://trello.com/c/l5FUibvy/41-hamburger-button-on-the-blog-starter-template-doesnt-work)
