### PR TITLE
Fix active pagination CSS class collision problem

### DIFF
--- a/source/blog.blade.php
+++ b/source/blog.blade.php
@@ -34,7 +34,7 @@ pagination:
                 <a
                     href="{{ $path }}"
                     title="Go to Page {{ $pageNumber }}"
-                    class="bg-gray-200 hover:bg-gray-400 text-blue-700 rounded mr-3 px-5 py-3 {{ $pagination->currentPage == $pageNumber ? 'text-blue-600' : '' }}"
+                    class="bg-gray-200 hover:bg-gray-400 rounded mr-3 px-5 py-3 {{ $pagination->currentPage == $pageNumber ? 'text-blue-600' : 'text-blue-700' }}"
                 >{{ $pageNumber }}</a>
             @endforeach
 


### PR DESCRIPTION
Since both `.text-blue-700` and `.text-blue-600` currently get applied to the active pagination item, the browser is left to determine which one to apply. Since `.text-blue-700` appears later in the generated CSS file, that will always win the collision war and the active pagination item won't appear any different from the others. This fix prevents that from being an issue by only applying the proper text color class.