### PR TITLE
Remove 'staging' env

### DIFF
--- a/config.production.php
+++ b/config.production.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'baseUrl' => 'https://my-jigsaw-blog.com',
+    'baseUrl' => 'https://jigsaw-blog-template.tighten.co',
     'production' => true,
 ];

--- a/config.staging.php
+++ b/config.staging.php
@@ -1,6 +1,0 @@
-<?php
-
-return [
-    'baseUrl' => 'http://jigsaw-blog-staging.tighten.co',
-    'production' => false,
-];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "scripts": {
         "dev": "mix",
         "watch": "mix watch",
-        "staging": "NODE_ENV=staging mix",
         "prod": "mix --production"
     },
     "devDependencies": {


### PR DESCRIPTION
Removes the `config.staging.php` file and uses `config.production.php` for our own hosted demo.