### PR TITLE
Update highlight.js to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "browser-sync-webpack-plugin": "^2.3.0",
         "fast-glob": "^3.2.12",
         "fuse.js": "^6.4.6",
-        "highlight.js": "^10.5.0",
+        "highlight.js": "^11.7.0",
         "laravel-mix": "^6.0.39",
         "laravel-mix-jigsaw": "^2.0.0",
         "postcss": "^8.4.21",

--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -15,7 +15,7 @@ hljs.registerLanguage('scss', require('highlight.js/lib/languages/scss'));
 hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'));
 
 document.querySelectorAll('pre code').forEach((block) => {
-    hljs.highlightBlock(block);
+    hljs.highlightElement(block);
 });
 
 Vue.config.productionTip = false;


### PR DESCRIPTION
* Updates highlight.js to `11.7.0` in `package.json`.
* Updates `highlightBlock` to `highlightElement` in `main.js`. `highlightBlock` is deprecated and will be removed in v12 (see screenshot below). This is only a name change according to the [v11 ugrade docs](https://github.com/highlightjs/highlight.js/blob/main/VERSION_11_UPGRADE.md#api-changes). 

<img width="535" alt="Screenshot 2023-04-06 at 4 26 09 PM" src="https://user-images.githubusercontent.com/24902327/230513747-1067521c-22c8-4bcd-8caa-8be1345f4ab8.png">

You can see the warning above on `main` at any blog post with code blocks (`/blog/customizing-your-site/` for example).

