### PR TITLE
Fix Sitemap Generator

### DIFF
--- a/listeners/GenerateSitemap.php
+++ b/listeners/GenerateSitemap.php
@@ -18,7 +18,7 @@ class GenerateSitemap
     {
         $baseUrl = $jigsaw->getConfig('baseUrl');
 
-        if (! $baseUrl) {
+        if (!$baseUrl) {
             echo("\nTo generate a sitemap.xml file, please specify a 'baseUrl' in config.php.\n\n");
 
             return;
@@ -30,8 +30,11 @@ class GenerateSitemap
             ->reject(function ($path) {
                 return $this->isExcluded($path);
             })->each(function ($path) use ($baseUrl, $sitemap) {
-                $sitemap->addItem(rtrim($baseUrl, '/') . $path, time(), Sitemap::DAILY);
-        });
+                $url = rtrim($baseUrl, '/') . $path;
+                $url = $url !== $baseUrl ? $url . '/' : $url;
+
+                $sitemap->addItem($url, time(), Sitemap::DAILY);
+            });
 
         $sitemap->write();
     }


### PR DESCRIPTION
I added the sitemap.xml on Google Search Console, and it was refusing to index inner URLs because the generator writes them without a slash at the end. 

If you access the following URL: https://leopoletto.com/invalidating-sessions-on-other-devices-on-laravel
It redirects to the version with the slash because it is a directory. 

This PR fixes this issue by adding the slash at the end of the inner URLs. 

## Evidences

![image](https://github.com/tighten/jigsaw-blog-template/assets/1036401/5ae35a40-c63e-45bc-9f0f-802370a676e1)

![image](https://github.com/tighten/jigsaw-blog-template/assets/1036401/a9dca0e3-74a6-470a-99ec-b8ef899b6e34)

## Final Result

https://leopoletto.com/sitemap.xml

![image](https://github.com/tighten/jigsaw-blog-template/assets/1036401/2cf0fdba-266f-4f7b-833a-488574494798)

