### PR TITLE
fix: bootstrap.php docblock

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,7 +1,9 @@
 <?php
 
-// @var $container \Illuminate\Container\Container
-// @var $events \TightenCo\Jigsaw\Events\EventBus
+/**
+ * @var \Illuminate\Container\Container $container
+ * @var \TightenCo\Jigsaw\Events\EventBus $events
+ */
 
 /*
  * You can run custom code at different stages of the build process by


### PR DESCRIPTION
According to [DocBlock specs](https://docs.phpdoc.org/guide/references/phpdoc/tags/var.html) and so IDEs can understand these and support "go to definition" click-through functionalities it feels like this is how this DocBlock should be written.