### PR TITLE
fix: navigation active text color matching logo

### DIFF
--- a/source/_nav/menu.blade.php
+++ b/source/_nav/menu.blade.php
@@ -1,16 +1,16 @@
 <nav class="hidden lg:flex items-center justify-end text-lg">
     <a title="{{ $page->siteName }} Blog" href="/blog"
-        class="ml-6 text-gray-700 hover:text-blue-600 {{ $page->isActive('/blog') ? 'active text-blue-600' : '' }}">
+        class="ml-6 hover:text-blue-600 {{ $page->isActive('/blog') ? 'active text-blue-800' : 'text-gray-700' }}">
         Blog
     </a>
 
     <a title="{{ $page->siteName }} About" href="/about"
-        class="ml-6 text-gray-700 hover:text-blue-600 {{ $page->isActive('/about') ? 'active text-blue-600' : '' }}">
+        class="ml-6 hover:text-blue-600 {{ $page->isActive('/about') ? 'active text-blue-800' : 'text-gray-700' }}">
         About
     </a>
 
     <a title="{{ $page->siteName }} Contact" href="/contact"
-        class="ml-6 text-gray-700 hover:text-blue-600 {{ $page->isActive('/contact') ? 'active text-blue-600' : '' }}">
+        class="ml-6 hover:text-blue-600 {{ $page->isActive('/contact') ? 'active text-blue-800' : 'text-gray-700' }}">
         Contact
     </a>
 </nav>


### PR DESCRIPTION
Also using the `else` so we don't end up with conflicting Tailwind classes for the text color which would mean the order would matter.